### PR TITLE
Add support for loading from dict config

### DIFF
--- a/teams_logger/core.py
+++ b/teams_logger/core.py
@@ -1,5 +1,5 @@
 import json
-from logging import Handler, LogRecord
+from logging import Handler, LogRecord, NOTSET
 from typing import Iterable
 
 import requests
@@ -20,7 +20,7 @@ class TeamsHandler(Handler):
     """
     Logging handler for Microsoft Teams webhook integration.
     """
-    def __init__(self, url, level):
+    def __init__(self, url, level=NOTSET):
         """
         :param url: Microsoft Teams incoming webhook url.
         :param level: Logging level (INFO, DEBUG, ERROR...etc)


### PR DESCRIPTION
Hi,

I used your library in a DJANGO project, where our logging config is loaded via a dict.
The non-optional `level` parameter in the `__init__` method was not compatible with this, so I made some minimal changes to be compatible (and added 2 tests). 

Feel free to consider my suggestions. I have a few more, in case you are accepting PRs.

BTW: Actually, looking at the `StreamHandler` class in the source code (https://github.com/python/cpython/blob/3.8/Lib/logging/__init__.py#L1038), I think the `level` parameter shouldn't be there at all. Also, the `dictConfig`'s `configure` call  sets the level using a handler's `setLevel` method and not using it's constructor `__init__`; see (https://github.com/python/cpython/blob/3.8/Lib/logging/config.py#L515)