### PR TITLE
Add nonblocking Teams handler

### DIFF
--- a/teams_logger/core.py
+++ b/teams_logger/core.py
@@ -62,11 +62,11 @@ class NBTeamsHandler(QueueHandler):
     """
 
     def __init__(self, url):
-        self.log_queue = queue.Queue(-1)
-        super().__init__(self.log_queue)
+        self._log_queue = queue.Queue(-1)
+        super().__init__(self._log_queue)
 
         teams_handler = TeamsHandler(url)
-        teams_log_listener = QueueListener(self.log_queue, teams_handler)
+        teams_log_listener = QueueListener(self._log_queue, teams_handler)
         teams_log_listener.start()
 
 

--- a/teams_logger/core.py
+++ b/teams_logger/core.py
@@ -1,10 +1,13 @@
 import json
+import queue
 from logging import Handler, LogRecord, NOTSET, Formatter
+from logging.handlers import QueueHandler, QueueListener
 from typing import Iterable
 
 import requests
 
-__all__ = ["TeamsHandler", "Office365CardFormatter", "TeamsCardsFormatter"]
+__all__ = ["TeamsHandler", "NBTeamsHandler",
+           "Office365CardFormatter", "TeamsCardsFormatter"]
 
 
 class TeamsCardsFormatter(Formatter):
@@ -19,6 +22,9 @@ class TeamsCardsFormatter(Formatter):
 class TeamsHandler(Handler):
     """
     Logging handler for Microsoft Teams webhook integration.
+
+    This handler blocks operation. Use non-blocking NBTeamsHandler for less
+    impact on your application performance.
     """
     def __init__(self, url, level=NOTSET):
         """
@@ -42,6 +48,26 @@ class TeamsHandler(Handler):
                           data=data)
         except Exception:
             self.handleError(record)
+
+
+class NBTeamsHandler(QueueHandler):
+    """
+    Non-blocking logging handler for Microsoft Teams webhook integration.
+
+    This handler reduces impact on your application compared to the (blocking)
+    TeamsHandler.
+
+    Queue-based implementation from
+    https://docs.python.org/3/howto/logging-cookbook.html#dealing-with-handlers-that-block
+    """
+
+    def __init__(self, url):
+        self.log_queue = queue.Queue(-1)
+        super().__init__(self.log_queue)
+
+        teams_handler = TeamsHandler(url)
+        teams_log_listener = QueueListener(self.log_queue, teams_handler)
+        teams_log_listener.start()
 
 
 class Office365CardFormatter(TeamsCardsFormatter):

--- a/tests/test_teams_logger.py
+++ b/tests/test_teams_logger.py
@@ -201,8 +201,12 @@ class TestNBTeamsHandler(unittest.TestCase):
         self.logger.log(self.log_level, self.log_text, self.log_parameter)
         # Call to Teams is handled in separate thread,
         # so wait until we have a signal it's processed
-        while not self.logger.handlers[0].log_queue.empty():
+        count = 0
+        while not self.logger.handlers[0]._log_queue.empty():
             time.sleep(0.1)
+            count += 1
+            if count >= 10:
+                self.fail("Log queue not processed in reasonable time")
         mock_requests.assert_called_with(url=self.url, headers={"Content-Type": "application/json"},
                                          data=self.expected_payload_with_default_formatter)
 


### PR DESCRIPTION
Support for a non-blocking teams handler was the reason for this (and my previous) PR(s).

I had a copy of your code already running on a system, but modified with support for a non-blocking teams handler. The standard (blocking) teams handler has too much impact on my application code.

If you decide to merge and release with the non-blocking handler, I can throw out the patched code, and switch back to just importing https://pypi.org/project/teams-logger/ 

Please verify if tests are also successful at your end; the multi-threading from the QueueListener required some unit test fiddling. Although I think the approach is sound.