### PR TITLE
Dict example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,3 +44,42 @@ Using Card Formatter
   logger.warn('warn message')
   logger.error('error message')
   logger.critical('critical message')
+
+
+
+Using dict configuration
+''''''''''''''''''''''''
+.. code-block:: python
+
+  import logging
+  import logging.config
+  from teams_logger import TeamsHandler, Office365CardFormatter
+
+  url = 'YOUR_WEB_HOOK_URL'
+  logging_dict = {
+      'version': 1, 
+      'disable_existing_loggers': False,
+      'formatters': {
+          'teamscard': {
+              '()': Office365CardFormatter,
+              'facts': ["name", "levelname", "lineno"],
+          },
+      },
+      'handlers': {
+          'msteams': {
+              'level': logging.INFO,
+              'class': 'teams_logger.TeamsHandler',
+              'url': url,
+              'formatter': 'teamscard',
+          },
+      },
+      'loggers': {
+          __name__: {
+              'handlers': ['msteams'],
+              'level': logging.DEBUG,
+          }
+      },
+  }
+  logging.config.dictConfig(logging_dict)
+  logger = logging.getLogger(__name__)
+  logger.info('Info message')


### PR DESCRIPTION
Add an example in the readme file on how to use a dict configuration with the card formatter.
Especially, the latter is not obvious, cfr. the use of `()` to refer to a custom formatter class.