### PR TITLE
Revert "Colored cards based on level"

### DIFF
--- a/teams_logger/core.py
+++ b/teams_logger/core.py
@@ -52,12 +52,6 @@ class Office365CardFormatter(TeamsCardsFormatter):
     In addition to the message, each log record attribute (levelname, lineno...etc) can be displayed as facts.
     """
     _facts = {"name", "levelname", "levelno", "lineno"}
-    _color_map = {"DEBUG": "#0000FF",  # blue
-                  "INFO": "#008000",    # green
-                  "WARNING": "#FFA500",  # orange
-                  "ERROR": "#FF0000",   # red
-                  "CRITICAL": "#8B0000",  # darkred
-                  }
 
     def __init__(self, facts: Iterable[str]):
         """
@@ -75,8 +69,6 @@ class Office365CardFormatter(TeamsCardsFormatter):
                     "facts": self._build_facts_list(record)
                 }
             ],
-            # Fallback to INFO color if needed
-            "themeColor": self._color_map.get(record.levelname, "INFO"),
             "text": record.getMessage()
         })
 


### PR DESCRIPTION
Reverts AnesFoufa/python-teams-logger#7
The fall back to INFO color is buggy